### PR TITLE
Fix(ui): Correct event handling for file actions menu

### DIFF
--- a/latexer/script.js
+++ b/latexer/script.js
@@ -519,20 +519,23 @@ Here is some math: $E = mc^2$
         const target = e.target.closest('a');
         if (!target) return;
 
-        e.preventDefault();
-
-        let path;
         if (target.classList.contains('action-menu-trigger')) {
+            e.preventDefault();
             const itemDiv = e.target.closest('.file-item, .folder-item');
-            path = itemDiv.dataset.path;
+            const path = itemDiv.dataset.path;
             const isFolder = itemDiv.classList.contains('folder-item');
             const textExtensions = ["tex", "bib", "bst", "cls", "cfg", "sty", "txt", "rnw"];
             const isText = !isFolder && textExtensions.includes(path.split('.').pop());
             showFileActionMenu(target, path, isFolder, isText);
-            return; // Stop further processing for the menu trigger itself
         }
+    });
 
-        path = target.dataset.path;
+    fileActionList.addEventListener('click', async (e) => {
+        const target = e.target.closest('a');
+        if (!target) return;
+
+        e.preventDefault();
+        const path = target.dataset.path;
         if (!path) return;
 
         if (target.classList.contains('action-edit')) {


### PR DESCRIPTION
This commit fixes a bug where the file action menu items (Edit, Delete, etc.) were not working. The issue was caused by incorrect event listener attachment. The event listener was attached to the file sidebar, but the menu is a separate element in the DOM.

The fix refactors the event handling:
1.  A new, dedicated event listener is added to the `fileActionList` element to handle clicks on the menu items.
2.  The existing event listener on the `fileListSidebar` is simplified to only be responsible for triggering the display of the action menu.

This change ensures that all file actions are now correctly triggered when selected from the three-dots menu.